### PR TITLE
Show text of add work week icon if there is room

### DIFF
--- a/app/src/main/res/menu/main_activity_menu.xml
+++ b/app/src/main/res/menu/main_activity_menu.xml
@@ -5,9 +5,8 @@
     <item
         android:id="@+id/add_work_week"
         android:title="Add Work Week"
-        app:showAsAction="ifRoom"
+        app:showAsAction="ifRoom|withText"
         android:icon="@drawable/ic_add_tip"
-
         />
 
     <item


### PR DESCRIPTION
The title of the add work week icon will be displayed along with the icon if there is room in the actionbar.